### PR TITLE
Change plugin ID to match grafana expectations

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "Centreon",
-  "id": "centreon-datasource",
+  "id": "centreon2-centreon-datasource",
   "metrics": true,
   "info": {
     "description": "Use Centreon datas in your dashboards",


### PR DESCRIPTION
https://grafana.com/docs/grafana/v7.5/developers/plugins/legacy/style-guide/#pluginjson-mandatory

>  The convention for the plugin id is `[github username/org]-[plugin name]-[datasource|app|panel]` and it has to be unique.